### PR TITLE
UX: Move user status

### DIFF
--- a/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -102,11 +102,7 @@
                 class="d-user-card__avatar"
               >{{bound-avatar this.user "huge"}}</a>
             {{/if}}
-            {{#if this.user.status}}
-              <UserStatusMessage @status={{this.user.status}} />
-            {{else}}
-              <UserAvatarFlair @user={{this.user}} />
-            {{/if}}
+            <UserAvatarFlair @user={{this.user}} />
             <div>
               <PluginOutlet
                 @name="user-card-avatar-flair"
@@ -177,6 +173,7 @@
                     {{if this.user.name " - "}}{{this.user.title}}
                   </span>
                 {{/if}}
+                <UserStatusMessage @status={{this.user.status}} />
               </div>
             </div>
           </div>

--- a/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -173,7 +173,9 @@
                     {{if this.user.name " - "}}{{this.user.title}}
                   </span>
                 {{/if}}
-                <UserStatusMessage @status={{this.user.status}} />
+                {{#if this.user.status}}
+                  <UserStatusMessage @status={{this.user.status}} />
+                {{/if}}
               </div>
             </div>
           </div>

--- a/scss/user-card.scss
+++ b/scss/user-card.scss
@@ -237,7 +237,6 @@
     display: flex;
   }
   &__user-title {
-    flex: 1 1 auto;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
Move status on usercard to after `team` title

<img width="300" alt="image" src="https://user-images.githubusercontent.com/30537603/227670126-be770248-f11c-4a0c-95ab-6f7f3ba58f54.png">
