### PR TITLE
UX: Darken usercard background in dark mode

### DIFF
--- a/common/color_definitions.scss
+++ b/common/color_definitions.scss
@@ -1,0 +1,11 @@
+$usercard-backdrop-avatar: dark-light-choose(
+  blur(30px),
+  blur(30px) brightness(0.8)
+);
+
+$usercard-backdrop: dark-light-choose(none, brightness(0.8));
+
+:root {
+  --usercard-backdrop-avatar: #{$usercard-backdrop-avatar};
+  --usercard-backdrop: #{$usercard-backdrop};
+}

--- a/scss/user-card.scss
+++ b/scss/user-card.scss
@@ -32,12 +32,12 @@
   overflow: hidden;
   &.avatar-background {
     .d-user-card__container {
-      backdrop-filter: blur(30px);
-      -webkit-backdrop-filter: blur(30px);
+      backdrop-filter: var(--usercard-backdrop-avatar);
     }
   }
   &__container {
     padding: 5px;
+    backdrop-filter: var(--usercard-backdrop);
   }
   &__header {
     height: 100px;


### PR DESCRIPTION
This PR sets the usercard background to be darker when in dark mode. This will prevent usercards with bright backgrounds from being too jarring in dark mode.

### After
<img width="400" alt="image" src="https://user-images.githubusercontent.com/30537603/233485090-b7e08d60-c76b-4410-bd19-1d8291ca9315.png">

### Before
<img width="400" alt="image" src="https://user-images.githubusercontent.com/30537603/233485160-a46e3ecc-a7e0-4653-85da-268e1aabacc1.png">
