### PR TITLE
CSS: border radius changes, button fixes

### DIFF
--- a/scss/user-card.scss
+++ b/scss/user-card.scss
@@ -33,11 +33,13 @@
   &.avatar-background {
     .d-user-card__container {
       backdrop-filter: var(--usercard-backdrop-avatar);
+      -webkit-backdrop-filter: var(--usercard-backdrop-avatar);
     }
   }
   &__container {
     padding: 5px;
     backdrop-filter: var(--usercard-backdrop);
+    -webkit-backdrop-filter: var(--usercard-backdrop);
   }
   &__header {
     height: 100px;
@@ -384,9 +386,15 @@
     margin: 0;
     gap: 0.5em;
   }
-  &__controls li {
+  &__controls li,
+  &__controls div {
     flex: 1 1;
     min-width: max-content;
+    display: flex;
+  }
+  &__controls div .btn {
+    border-radius: 4px;
+    flex: 1 1;
   }
   &__controls .chat-button {
     flex: 1 1;
@@ -396,9 +404,6 @@
   }
   &__controls li:empty {
     display: none;
-  }
-  &__action {
-    display: flex;
   }
   &__button {
     border: none;

--- a/scss/user-card.scss
+++ b/scss/user-card.scss
@@ -22,7 +22,7 @@
 .d-user-card {
   margin: 1em auto;
   width: 480px;
-  border-radius: 5px;
+  border-radius: var(--d-border-radius);
   box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.1);
   z-index: 1102;
   background: var(--user-background);
@@ -50,7 +50,7 @@
   }
   &__badges {
     display: flex;
-    border-radius: 4px;
+    border-radius: var(--d-border-radius);
     gap: 0.5em;
     margin-left: auto;
   }
@@ -64,7 +64,7 @@
     display: flex;
     padding: 5px 6px;
     background-color: rgba(var(--secondary-rgb), 1);
-    border-radius: 4px;
+    border-radius: var(--d-border-radius);
   }
   &__badges .user-card-badge-link:hover {
     background-color: var(--secondary-very-high);
@@ -81,7 +81,7 @@
     display: flex;
     padding: 5px 6px;
     background-color: rgba(var(--secondary-rgb), 1);
-    border-radius: 4px;
+    border-radius: var(--d-border-radius);
     align-items: center;
   }
   &__badges-more:hover {
@@ -130,7 +130,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    border-radius: 5px;
+    border-radius: var(--d-border-radius);
     background-color: var(--secondary);
     padding: 0.5em;
   }
@@ -253,7 +253,7 @@
     width: min-content;
     background-color: rgba(var(--secondary-rgb), 0.75);
     padding: 6px;
-    border-radius: 4px;
+    border-radius: var(--d-border-radius);
     gap: 0.5em;
   }
   &__time {
@@ -304,7 +304,7 @@
     font-size: var(--font-down-2);
     margin-bottom: 1em;
     padding: 0.5em;
-    border-radius: 5px;
+    border-radius: var(--d-border-radius);
   }
   &__bio {
     margin-bottom: 0.75em;
@@ -343,7 +343,7 @@
   &__field {
     padding: 3px 5px;
     display: flex;
-    border-radius: 5px;
+    border-radius: var(--d-border-radius);
     align-items: center;
   }
   &__meta-data {
@@ -393,13 +393,13 @@
     display: flex;
   }
   &__controls div .btn {
-    border-radius: 4px;
+    border-radius: var(--d-border-radius);
     flex: 1 1;
   }
-  &__controls .chat-button {
+  &__controls .chat-user-card-btn {
     flex: 1 1;
   }
-  &__controls .chat-button div {
+  &__controls .chat-user-card-btn div {
     display: flex;
   }
   &__controls li:empty {
@@ -417,7 +417,7 @@
     flex-grow: 1;
     cursor: pointer;
     transition: all 0.25s;
-    border-radius: 4px;
+    border-radius: var(--d-border-radius);
     margin: 0;
   }
   .user-card-chat-btn {
@@ -432,7 +432,7 @@
     flex-grow: 1;
     cursor: pointer;
     transition: all 0.25s;
-    border-radius: 4px;
+    border-radius: var(--d-border-radius);
     margin: 0;
   }
 }
@@ -457,7 +457,7 @@
     flex-grow: 1;
     cursor: pointer;
     transition: all 0.25s;
-    border-radius: 4px;
+    border-radius: var(--d-border-radius);
     margin: 0;
   }
 }
@@ -465,7 +465,7 @@
 .user-card-metadata-outlet h3 {
   padding: 3px 5px;
   display: flex;
-  border-radius: 5px;
+  border-radius: var(--d-border-radius);
   font-size: var(--font-0);
   span.desc {
     color: var(--primary);
@@ -548,7 +548,7 @@ body:not(.staff) {
   display: flex;
   // padding: 4px 6px;
   background-color: rgba(var(--secondary-rgb), 0.75);
-  border-radius: 4px;
+  border-radius: var(--d-border-radius);
   &:not(:has(*)) {
     display: none;
   }


### PR DESCRIPTION
This PR fixes an issue where the chat button was not using its `flex: 1 1` style due to an updated css class in core.

It also removes the set border width and will inherit whatever border width is used in the theme installed on the forum.

**Before**
<img width="500" alt="image" src="https://github.com/discourse/experimental-usercard/assets/30537603/e7179b6a-e34d-4460-a82f-41cae22dfd66">

**After**
<img width="500" alt="image" src="https://github.com/discourse/experimental-usercard/assets/30537603/cab0b67f-1cb4-45a1-b665-30bb1620a460">
