### PR TITLE
DEV: Fix LinkTo deprecations

### DIFF
--- a/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -186,13 +186,13 @@
                     "pushpin"
                   }}</span>
                 <LinkTo
-                  @title={{i18n "user.featured_topic"}}
                   @route="topic"
-                  @class="d-user-card__link"
                   @models={{array
                     this.user.featured_topic.slug
                     this.user.featured_topic.id
                   }}
+                  title={{i18n "user.featured_topic"}}
+                  class="d-user-card__link"
                 >{{replace-emoji
                     (html-safe this.user.featured_topic.fancy_title)
                   }}</LinkTo>


### PR DESCRIPTION
```
DEPRECATION: Passing the `@class` argument to <LinkTo> is deprecated. Instead, please pass the attribute directly, i.e. `<LinkTo class={{...}} />` instead of `<LinkTo @class={{...}} />` or `{{link-to class=...}}`. [deprecation id: ember.built-in-components.legacy-attribute-arguments] See https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-attribute-arguments for more details.
```

```
DEPRECATION: Passing the `@title` argument to <LinkTo> is deprecated. Instead, please pass the attribute directly, i.e. `<LinkTo title={{...}} />` instead of `<LinkTo @title={{...}} />` or `{{link-to title=...}}`. [deprecation id: ember.built-in-components.legacy-attribute-arguments] See https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-legacy-attribute-arguments for more details.
```