### PR TITLE
DEV: Update deprecated Font Awesome icon names

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,3 @@
+< 3.4.0.beta2-dev: 8f0fb67192cded0b9f737fe1a82f39d2b926ace2
 < 3.4.0.beta1-dev: eb3ed1efeedfa7e74f527d0c204836388f9e0027
 < 3.3.0.beta1-dev: 373a18b932ba06e9897a8d83016b145d2c027de7

--- a/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -56,7 +56,7 @@
               {{/if}}
               {{#if this.user.location}}
                 <div class="d-user-card__location">
-                  {{d-icon "map-marker-alt"}}
+                  {{d-icon "location-dot"}}
                   {{#if this.themeSettingValid}}
                     <a
                       href={{this.userLocationLink}}


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.