### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/javascripts/discourse/templates/components/user-card-contents.hbs
+++ b/javascripts/discourse/templates/components/user-card-contents.hbs
@@ -406,7 +406,7 @@
                   <DButton
                     class="d-user-card__button btn-default"
                     @action={{action "cancelFilter"}}
-                    @icon="times"
+                    @icon="xmark"
                     @label="topic.filters.cancel"
                   />
                 </li>
@@ -417,7 +417,7 @@
                     class="d-user-card__button btn-danger"
                     @action={{action "deleteUser"}}
                     @actionParam={{this.user}}
-                    @icon="exclamation-triangle"
+                    @icon="triangle-exclamation"
                     @label="admin.user.delete"
                   />
                 </li>


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.